### PR TITLE
Prevent duplicate weight goals for the same deadline

### DIFF
--- a/goalsweight.js
+++ b/goalsweight.js
@@ -266,6 +266,17 @@ if (saveGoalBtn) {
                 const data = snap.data() || {};
                 const goals = data.goals || [];
 
+
+                
+                //this code is for preventing duplicate goals on the same deadline
+                if (type === 'weight') {
+                  const existingGoal = goals.find(g => g.type === 'weight' && g.deadline === deadline);
+                  if (existingGoal) {
+                    alert("⚠️ A weight goal already exists for this deadline.");
+                    return;
+                  }
+                }
+                
                 goals.push({
                     type,
                     target: Number(target),


### PR DESCRIPTION
fix: prevent duplicate weight goals for the same deadline

Added validation to block users from saving multiple weight goals with the same deadline.
Ensures data consistency and avoids conflicting progress indicators.


if (type === 'weight') {
const existingGoal = goals.find(g => g.type === 'weight' && g.deadline === deadline);
if (existingGoal) {
alert("⚠️ A weight goal already exists for this deadline.");
return;
}
}
